### PR TITLE
bump flutter_svg to a null-safe version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mono_kit
 description: A collection of convenient widgets and utils made by mono. Under construction now.
-version: 0.18.2-dev
+version: 0.18.3-dev
 homepage: https://github.com/mono0926/flutter_mono_kit
 environment:
   sdk: ">=2.6.0 <3.0.0"
@@ -22,7 +22,7 @@ dependencies:
   subscription_holder: ">=2.0.0 <3.0.0"
   simple_logger: ">=1.6.0 <2.0.0"
   tinycolor: ">=1.0.0 <2.0.0"
-  flutter_svg: ">=0.18.0 <1.0.0"
+  flutter_svg: ">=0.20.0-nullsafety.3 <1.0.0"
   state_notifier: ">=0.6.0 <1.0.0"
   flutter_hooks: ">=0.13.0 <1.0.0"
 dev_dependencies:


### PR DESCRIPTION
I believe this could fix https://github.com/mono0926/adaptive_dialog/issues/26 (once the mono_kit dependency version is updated) but this entire package still needs to be made null safe, because the null-safe adaptive_dialog depends on it.