### PR TITLE
fix(ios): SPM対応の改善 (プラットフォーム構文及びSwift単一ターゲット化)

### DIFF
--- a/ios/mono_kit/Package.swift
+++ b/ios/mono_kit/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "mono_kit",
     platforms: [
-        .iOS("13.0")
+        .iOS(.v13)
     ],
     products: [
         .library(name: "mono-kit", targets: ["mono_kit"])

--- a/ios/mono_kit/Sources/mono_kit/MonoKitPlugin.h
+++ b/ios/mono_kit/Sources/mono_kit/MonoKitPlugin.h
@@ -1,4 +1,0 @@
-#import <Flutter/Flutter.h>
-
-@interface MonoKitPlugin : NSObject<FlutterPlugin>
-@end

--- a/ios/mono_kit/Sources/mono_kit/MonoKitPlugin.m
+++ b/ios/mono_kit/Sources/mono_kit/MonoKitPlugin.m
@@ -1,8 +1,0 @@
-#import "MonoKitPlugin.h"
-#import <mono_kit/mono_kit-Swift.h>
-
-@implementation MonoKitPlugin
-+ (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
-  [SwiftMonoKitPlugin registerWithRegistrar:registrar];
-}
-@end

--- a/ios/mono_kit/Sources/mono_kit/MonoKitPlugin.swift
+++ b/ios/mono_kit/Sources/mono_kit/MonoKitPlugin.swift
@@ -1,10 +1,10 @@
 import Flutter
 import UIKit
 
-public class SwiftMonoKitPlugin: NSObject, FlutterPlugin {
+public class MonoKitPlugin: NSObject, FlutterPlugin {
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(name: "mono_kit", binaryMessenger: registrar.messenger())
-    let instance = SwiftMonoKitPlugin()
+    let instance = MonoKitPlugin()
     registrar.addMethodCallDelegate(instance, channel: channel)
   }
 


### PR DESCRIPTION
## 概要
PR #10 でいただいた Copilot からのレビューフィードバックを反映しました。

## 反映内容
1. **Package.swift の platforms 構文改善**
   - `.iOS("13.0")` ➔ `.iOS(.v13)` に変更し、SwiftPM の型安全なバージョン表記に合わせました。
2. **Swift / ObjC 混在ターゲットの解消（Swift 単一化）**
   - 旧 ObjC ラッパー `MonoKitPlugin.h` / `MonoKitPlugin.m` を削除。
   - `SwiftMonoKitPlugin.swift` を `MonoKitPlugin.swift` に改名し、クラス名を `MonoKitPlugin` に統一。
   - SwiftPM / CocoaPods の双方で Swift-only プラグインとして正しくビルドできるように改善しました。